### PR TITLE
 fix: Link error in reference

### DIFF
--- a/cn/role-manual/faq/how-to-get-vrma.mdx
+++ b/cn/role-manual/faq/how-to-get-vrma.mdx
@@ -41,7 +41,7 @@ VRM Animation 的官方文档和规范可在 GitHub 上找到。
 <Accordion title="参考资料">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/cn/role-manual/faq/how-to-use-vroid-hub.mdx
+++ b/cn/role-manual/faq/how-to-use-vroid-hub.mdx
@@ -103,5 +103,5 @@ VRM 是一种用于处理 3D 角色模型的文件格式，具有以下特点：
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>

--- a/cn/role-manual/faq/what-is-vrma-file.mdx
+++ b/cn/role-manual/faq/what-is-vrma-file.mdx
@@ -35,7 +35,6 @@ icon: question
 
 <Accordion title="参考资料">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/cn/role-manual/resources/vrm-official-doc.mdx
+++ b/cn/role-manual/resources/vrm-official-doc.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM官方文档-汉化版
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/docs/role-manual/faq/how-to-get-vrma.en-US.mdx
+++ b/docs/role-manual/faq/how-to-get-vrma.en-US.mdx
@@ -40,7 +40,7 @@ These resources provide you with a wealth of tools and platforms to acquire and 
 <Accordion title="References">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/docs/role-manual/faq/how-to-get-vrma.fr-FR.mdx
+++ b/docs/role-manual/faq/how-to-get-vrma.fr-FR.mdx
@@ -40,7 +40,7 @@ Ces ressources vous offrent une multitude d'outils et de plateformes pour obteni
 <Accordion title="Références">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/docs/role-manual/faq/how-to-get-vrma.ja-JP.mdx
+++ b/docs/role-manual/faq/how-to-get-vrma.ja-JP.mdx
@@ -40,7 +40,7 @@ VRM Animation の公式ドキュメントと仕様は GitHub で入手できま�
 <Accordion title="参考資料">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/docs/role-manual/faq/how-to-get-vrma.zh-CN.mdx
+++ b/docs/role-manual/faq/how-to-get-vrma.zh-CN.mdx
@@ -41,7 +41,7 @@ VRM Animation 的官方文档和规范可在 GitHub 上找到。
 <Accordion title="参考资料">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/docs/role-manual/faq/how-to-use-vroid-hub.en-US.mdx
+++ b/docs/role-manual/faq/how-to-use-vroid-hub.en-US.mdx
@@ -103,6 +103,6 @@ On the homepage of VRoid Hub, you can search for available avatars using the sea
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/docs/role-manual/faq/how-to-use-vroid-hub.fr-FR.mdx
+++ b/docs/role-manual/faq/how-to-use-vroid-hub.fr-FR.mdx
@@ -103,6 +103,6 @@ Sur la page d'accueil de VRoid Hub, vous pouvez rechercher des avatars disponibl
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/docs/role-manual/faq/how-to-use-vroid-hub.ja-JP.mdx
+++ b/docs/role-manual/faq/how-to-use-vroid-hub.ja-JP.mdx
@@ -103,6 +103,6 @@ VRoid Hubのホームページでは、検索ボックスやカテゴリブラ�
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/docs/role-manual/faq/how-to-use-vroid-hub.zh-CN.mdx
+++ b/docs/role-manual/faq/how-to-use-vroid-hub.zh-CN.mdx
@@ -103,5 +103,5 @@ VRM 是一种用于处理 3D 角色模型的文件格式，具有以下特点：
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>

--- a/docs/role-manual/faq/what-is-vrma-file.en-US.mdx
+++ b/docs/role-manual/faq/what-is-vrma-file.en-US.mdx
@@ -38,7 +38,6 @@ By using .vrma files, users can conveniently implement complex character animati
 
 <Accordion title="References">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/docs/role-manual/faq/what-is-vrma-file.fr-FR.mdx
+++ b/docs/role-manual/faq/what-is-vrma-file.fr-FR.mdx
@@ -38,7 +38,6 @@ En utilisant des fichiers .vrma, les utilisateurs peuvent facilement réaliser d
 
 <Accordion title="Références">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/docs/role-manual/faq/what-is-vrma-file.ja-JP.mdx
+++ b/docs/role-manual/faq/what-is-vrma-file.ja-JP.mdx
@@ -38,7 +38,6 @@ icon: question
 
 <Accordion title="参考資料">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/docs/role-manual/faq/what-is-vrma-file.zh-CN.mdx
+++ b/docs/role-manual/faq/what-is-vrma-file.zh-CN.mdx
@@ -35,7 +35,6 @@ icon: question
 
 <Accordion title="参考资料">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/docs/role-manual/resources/vrm-official-doc.en-US.mdx
+++ b/docs/role-manual/resources/vrm-official-doc.en-US.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM Official Documentation - Translated Version
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/docs/role-manual/resources/vrm-official-doc.fr-FR.mdx
+++ b/docs/role-manual/resources/vrm-official-doc.fr-FR.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation officielle de VRM - Version traduite
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/docs/role-manual/resources/vrm-official-doc.ja-JP.mdx
+++ b/docs/role-manual/resources/vrm-official-doc.ja-JP.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM公式ドキュメント - 和訳版
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/docs/role-manual/resources/vrm-official-doc.zh-CN.mdx
+++ b/docs/role-manual/resources/vrm-official-doc.zh-CN.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM官方文档-汉化版
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/en/role-manual/faq/how-to-get-vrma.mdx
+++ b/en/role-manual/faq/how-to-get-vrma.mdx
@@ -40,7 +40,7 @@ These resources provide you with a wealth of tools and platforms to acquire and 
 <Accordion title="References">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/en/role-manual/faq/how-to-use-vroid-hub.mdx
+++ b/en/role-manual/faq/how-to-use-vroid-hub.mdx
@@ -103,6 +103,6 @@ On the homepage of VRoid Hub, you can search for available avatars using the sea
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/en/role-manual/faq/what-is-vrma-file.mdx
+++ b/en/role-manual/faq/what-is-vrma-file.mdx
@@ -38,7 +38,6 @@ By using .vrma files, users can conveniently implement complex character animati
 
 <Accordion title="References">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/en/role-manual/resources/vrm-official-doc.mdx
+++ b/en/role-manual/resources/vrm-official-doc.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM Official Documentation - Translated Version
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/fr/role-manual/faq/how-to-get-vrma.mdx
+++ b/fr/role-manual/faq/how-to-get-vrma.mdx
@@ -40,7 +40,7 @@ Ces ressources vous offrent une multitude d'outils et de plateformes pour obteni
 <Accordion title="Références">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/fr/role-manual/faq/how-to-use-vroid-hub.mdx
+++ b/fr/role-manual/faq/how-to-use-vroid-hub.mdx
@@ -103,6 +103,6 @@ Sur la page d'accueil de VRoid Hub, vous pouvez rechercher des avatars disponibl
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/fr/role-manual/faq/what-is-vrma-file.mdx
+++ b/fr/role-manual/faq/what-is-vrma-file.mdx
@@ -38,7 +38,6 @@ En utilisant des fichiers .vrma, les utilisateurs peuvent facilement réaliser d
 
 <Accordion title="Références">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/fr/role-manual/resources/vrm-official-doc.mdx
+++ b/fr/role-manual/resources/vrm-official-doc.mdx
@@ -1,6 +1,6 @@
 ---
 title: Documentation officielle de VRM - Version traduite
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 

--- a/jp/role-manual/faq/how-to-get-vrma.mdx
+++ b/jp/role-manual/faq/how-to-get-vrma.mdx
@@ -40,7 +40,7 @@ VRM Animation の公式ドキュメントと仕様は GitHub で入手できま�
 <Accordion title="参考資料">
   [1] https://vroid.com/en/news/6HozzBIV0KkcKf9dc1fZGW  
   [2] https://elvcatdev.com/posts/vrma-vpd-effect/  
-  [3] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
+  [3] https://docs.vrcd.org.cn/books/vrm-vrm  
   [4] https://www.youtube.com/watch?v=GCXln4SX-7I  
   [5] https://vrm.dev/en/vrma/  
   [6] https://developer.vive.com/resources/openxr/unreal/unreal-tutorials/facialexpressionmaker/vrm/?site=cn  

--- a/jp/role-manual/faq/how-to-use-vroid-hub.mdx
+++ b/jp/role-manual/faq/how-to-use-vroid-hub.mdx
@@ -103,6 +103,6 @@ VRoid Hubのホームページでは、検索ボックスやカテゴリブラ�
   [4] https://avatar.viverse.com/zh-TW/avatar/what-is-vrm  
   [5] https://tips.clip-studio.com/zh-tw/articles/3388  
   [6] https://www.87g.com/az/81153.html  
-  [7] https://docs.vrcd.org.cn/books/vrm-vrm/export/html
+  [7] https://docs.vrcd.org.cn/books/vrm-vrm
 </Accordion>
 

--- a/jp/role-manual/faq/what-is-vrma-file.mdx
+++ b/jp/role-manual/faq/what-is-vrma-file.mdx
@@ -38,7 +38,6 @@ icon: question
 
 <Accordion title="参考資料">
   [1] https://docs.vrcd.org.cn/books/vrm-vrm  
-  [2] https://docs.vrcd.org.cn/books/vrm-vrm/export/html  
   [3] https://vrm.dev/en/vrma/  
   [4] https://vocus.cc/article/65dc15f1fd89780001f80eb7  
   [5] https://elvcatdev.com/posts/vrma-vpd-effect/  

--- a/jp/role-manual/resources/vrm-official-doc.mdx
+++ b/jp/role-manual/resources/vrm-official-doc.mdx
@@ -1,6 +1,6 @@
 ---
 title: VRM公式ドキュメント - 和訳版
-url: 'https://docs.vrcd.org.cn/books/vrm-vrm/export/html'
+url: 'https://docs.vrcd.org.cn/books/vrm-vrm'
 icon: link
 ---
 


### PR DESCRIPTION
现有的VRCD相关链接大部分都包含了 `/export/html` ，访问这个页面会直接下载一个html文件